### PR TITLE
Use uri.file instead of uri.path in TypeItem.uri()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,7 +213,7 @@ class TypeItem implements vscode.QuickPickItem {
   }
 
   public uri() : vscode.Uri {
-    return vscode.Uri.parse(`file://${this.path()}`)
+    return vscode.Uri.file(this.path())
   }
 
   public exists() : boolean {


### PR DESCRIPTION
On windows, the current implementation of TypeItem.uri() fails due to incorrect file path (slash/backslash problem, example: `file://c:\My Project\app\templates\application.hbs` ).

Using `Uri.file(this.path)` instead of ``Uri.parse(`file://${this.path()}`)`` fixes this on Windows.
I've couldn't verify if this also works on Mac/Linux.