### PR TITLE
fix osx shortcut and bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 *.vsix
+.vscode-test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "7.0"
+  - "8.2.1"
 
 os:
   - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix osx shortcut in README.md
+
 ## 1.0.1
 - Fix opening files on windows ([#1](https://github.com/josa42/vscode-ember-related-files/pull/1))
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Default keybinding
 
-- **Mac**: <kbd>`cmd`</kbd> + <kbd>`r`</kbd>
+- **Mac**: <kbd>`alt`</kbd> + <kbd>`cmd`</kbd> + <kbd>`r`</kbd>
 - **Win/Linux**: <kbd>`alt`</kbd> + <kbd>`ctrl`</kbd> + <kbd>`r`</kbd>
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
     "name": "ember-related-files",
     "version": "1.1.0",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/mocha": {
             "version": "2.2.41",
@@ -10,16 +11,20 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.0.78",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
-            "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg==",
+            "version": "8.0.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.19.tgz",
+            "integrity": "sha512-VRQB+Q0L3YZWs45uRdpN9oWr82meL/8TrJ6faoKT5tp0uub2l/aRMhtm5fo68h7kjYKH60f9/bay1nF7ZpTW5g==",
             "dev": true
         },
         "ajv": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -37,7 +42,10 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.0.3"
+            }
         },
         "arr-flatten": {
             "version": "1.0.3",
@@ -55,7 +63,10 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -115,7 +126,10 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
         },
         "beeper": {
             "version": "1.1.1",
@@ -127,24 +141,39 @@
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "boom": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
         },
         "brace-expansion": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+            }
         },
         "braces": {
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
         },
         "browser-stdout": {
             "version": "1.3.0",
@@ -169,6 +198,13 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.2",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            },
             "dependencies": {
                 "supports-color": {
                     "version": "2.0.0",
@@ -200,7 +236,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
             "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "process-nextick-args": "1.0.7",
+                "through2": "2.0.3"
+            }
         },
         "co": {
             "version": "4.6.0",
@@ -212,13 +253,10 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-            "dev": true
-        },
-        "commander": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-            "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
         },
         "concat-map": {
             "version": "0.0.1",
@@ -241,13 +279,19 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1"
+            }
         },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -263,28 +307,19 @@
             "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
             "dev": true
         },
-        "debug": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-            "dev": true
-        },
         "deep-assign": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
-        "diff": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
             "dev": true
         },
         "duplexer": {
@@ -298,6 +333,9 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
+            "requires": {
+                "readable-stream": "1.1.14"
+            },
             "dependencies": {
                 "isarray": {
                     "version": "0.0.1",
@@ -309,7 +347,13 @@
                     "version": "1.1.14",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -323,31 +367,49 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
             "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.11",
+                "stream-shift": "1.0.0"
+            }
         },
         "ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
         },
         "ember-find-related-files": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/ember-find-related-files/-/ember-find-related-files-0.3.0.tgz",
-            "integrity": "sha512-pHknUXUadvihURMvPERVx/nyYDmBr9ax6r9DZSg0E/py50axQ3L6rLqIQbqIHoEjrWpUMhs690lpg9CJrLqHSA=="
+            "integrity": "sha512-pHknUXUadvihURMvPERVx/nyYDmBr9ax6r9DZSg0E/py50axQ3L6rLqIQbqIHoEjrWpUMhs690lpg9CJrLqHSA==",
+            "requires": {
+                "glob": "7.1.2"
+            }
         },
         "end-of-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
             "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
             "dev": true,
+            "requires": {
+                "once": "1.3.3"
+            },
             "dependencies": {
                 "once": {
                     "version": "1.3.3",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
                 }
             }
         },
@@ -361,19 +423,34 @@
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
         },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
         },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
         },
         "extend": {
             "version": "3.0.1",
@@ -385,13 +462,19 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extendable": "0.1.1"
+            }
         },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -411,13 +494,20 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.1.0"
+            }
         },
         "fd-slicer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pend": "1.2.0"
+            }
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -429,7 +519,14 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.6",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
         },
         "first-chunk-stream": {
             "version": "1.0.0",
@@ -447,7 +544,10 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -459,7 +559,12 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+            }
         },
         "from": {
             "version": "0.1.7",
@@ -476,7 +581,13 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+            }
         },
         "generate-function": {
             "version": "2.0.0",
@@ -488,13 +599,19 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
         },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -507,19 +624,34 @@
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
         },
         "glob-base": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            },
             "dependencies": {
                 "glob-parent": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
                 },
                 "is-extglob": {
                     "version": "1.0.0",
@@ -531,7 +663,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -539,19 +674,40 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            }
         },
         "glob-stream": {
             "version": "5.3.5",
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
+            },
             "dependencies": {
                 "glob": {
                     "version": "5.0.15",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "isarray": {
                     "version": "0.0.1",
@@ -563,7 +719,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -575,7 +737,11 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 }
             }
         },
@@ -583,7 +749,10 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -607,19 +776,33 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
+            }
         },
         "gulp-filter": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.0.tgz",
             "integrity": "sha1-z6gZZvtniE8rp1SwZxUpKUKNWbw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "gulp-util": "3.0.8",
+                "multimatch": "2.1.0",
+                "streamfilter": "1.0.5"
+            }
         },
         "gulp-gunzip": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
             "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
             "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -637,7 +820,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -649,13 +838,21 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
@@ -664,6 +861,13 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.2.tgz",
             "integrity": "sha1-zrN3DjREMo1hOG+6qrIAvBHNmKg=",
             "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.79.0",
+                "through2": "2.0.3",
+                "vinyl": "2.0.2"
+            },
             "dependencies": {
                 "clone-stats": {
                     "version": "1.0.0",
@@ -681,13 +885,44 @@
                     "version": "2.79.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "is-stream": "1.1.0",
+                        "remove-trailing-separator": "1.0.2",
+                        "replace-ext": "1.0.0"
+                    }
                 }
             }
         },
@@ -696,12 +931,24 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
+            "requires": {
+                "convert-source-map": "1.5.0",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
+            },
             "dependencies": {
                 "vinyl": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
                 }
             }
         },
@@ -709,19 +956,52 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
+            }
         },
         "gulp-untar": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "gulp-util": "3.0.8",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3"
+            }
         },
         "gulp-util": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.0.0",
+                "fancy-log": "1.3.0",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
+                "replace-ext": "0.0.1",
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
+            },
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
@@ -736,6 +1016,15 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
             "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
             "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "queue": "3.1.0",
+                "through2": "0.6.5",
+                "vinyl": "0.4.6",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.8.0",
+                "yazl": "2.4.2"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -753,7 +1042,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -765,13 +1060,21 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
@@ -779,7 +1082,10 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glogg": "1.0.0"
+            }
         },
         "har-schema": {
             "version": "1.0.5",
@@ -792,12 +1098,21 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.16.0",
+                "pinkie-promise": "2.0.1"
+            },
             "dependencies": {
                 "commander": {
                     "version": "2.9.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
                 }
             }
         },
@@ -805,7 +1120,10 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "has-flag": {
             "version": "1.0.0",
@@ -817,13 +1135,22 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
         },
         "hawk": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
         },
         "hoek": {
             "version": "2.16.3",
@@ -835,12 +1162,21 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.1"
+            }
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
         },
         "inherits": {
             "version": "2.0.3",
@@ -869,7 +1205,10 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -887,19 +1226,31 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
         },
         "is-my-json-valid": {
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
             "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+            }
         },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
         },
         "is-obj": {
             "version": "1.0.1",
@@ -959,33 +1310,16 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
         },
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
             "dev": true
-        },
-        "jade": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "dependencies": {
-                "commander": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -1004,7 +1338,10 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -1035,6 +1372,12 @@
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
             "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -1048,19 +1391,29 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.5"
+            }
         },
         "lazystream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.2.11"
+            }
         },
         "lodash._baseassign": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+            }
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -1126,13 +1479,21 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "3.2.0",
+                "lodash._basecreate": "3.0.3",
+                "lodash._isiterateecall": "3.0.9"
+            }
         },
         "lodash.escape": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
         },
         "lodash.isarguments": {
             "version": "3.1.0",
@@ -1156,7 +1517,12 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
         },
         "lodash.restparam": {
             "version": "3.6.1",
@@ -1168,19 +1534,28 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+            }
         },
         "lodash.templatesettings": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true
-        },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
+            }
         },
         "map-stream": {
             "version": "0.1.0",
@@ -1192,13 +1567,31 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.2.11"
+            }
         },
         "micromatch": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.3"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -1210,7 +1603,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -1224,12 +1620,18 @@
             "version": "2.1.15",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
             "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "mime-db": "1.27.0"
+            }
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "1.1.7"
+            }
         },
         "minimist": {
             "version": "0.0.8",
@@ -1241,57 +1643,129 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true
-        },
-        "mocha": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-            "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
             "dev": true,
-            "dependencies": {
-                "glob": {
-                    "version": "3.2.11",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true
-                }
+            "requires": {
+                "minimist": "0.0.8"
             }
         },
-        "ms": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-            "dev": true
+        "mocha": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+            "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.9.0",
+                "debug": "2.6.8",
+                "diff": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.1",
+                "growl": "1.9.2",
+                "json3": "3.3.2",
+                "lodash.create": "3.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "3.1.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "diff": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+                    "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                    "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
+                }
+            }
         },
         "multimatch": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
         },
         "multipipe": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.0.2"
+            }
         },
         "node.extend": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is": "3.2.1"
+            }
         },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.0.2"
+            }
         },
         "oauth-sign": {
             "version": "0.8.2",
@@ -1309,24 +1783,41 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1.0.2"
+            }
         },
         "ordered-read-streams": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-stream": "1.1.0",
+                "readable-stream": "2.2.11"
+            }
         },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -1338,7 +1829,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -1357,7 +1851,10 @@
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "pend": {
             "version": "1.2.0",
@@ -1381,7 +1878,10 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
         },
         "preserve": {
             "version": "0.2.0",
@@ -1411,25 +1911,45 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "randomatic": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
             "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "kind-of": "3.2.2"
+            }
         },
         "readable-stream": {
             "version": "2.2.11",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
             "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.0.1",
+                "string_decoder": "1.0.2",
+                "util-deprecate": "1.0.2"
+            }
         },
         "regex-cache": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
             "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+            }
         },
         "remove-trailing-separator": {
             "version": "1.0.2",
@@ -1460,6 +1980,30 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
+            "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+            },
             "dependencies": {
                 "caseless": {
                     "version": "0.12.0",
@@ -1471,7 +2015,11 @@
                     "version": "4.2.1",
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
                     "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
                 },
                 "qs": {
                     "version": "6.4.0",
@@ -1483,7 +2031,10 @@
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
                 }
             }
         },
@@ -1491,7 +2042,10 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
             "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
         },
         "safe-buffer": {
             "version": "5.0.1",
@@ -1505,17 +2059,14 @@
             "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
             "dev": true
         },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
-        },
         "sntp": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
         },
         "source-map": {
             "version": "0.5.6",
@@ -1527,7 +2078,10 @@
             "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
             "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.6"
+            }
         },
         "sparkles": {
             "version": "1.0.0",
@@ -1539,13 +2093,26 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "sshpk": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -1565,7 +2132,10 @@
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
         },
         "stream-shift": {
             "version": "1.0.0",
@@ -1577,7 +2147,10 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
             "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.2.11"
+            }
         },
         "streamifier": {
             "version": "0.1.1",
@@ -1589,7 +2162,10 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
             "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.0.1"
+            }
         },
         "stringstream": {
             "version": "0.0.5",
@@ -1601,31 +2177,40 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "strip-bom": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
         },
         "strip-bom-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-            "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
+            }
         },
         "tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
         },
         "through": {
             "version": "2.3.8",
@@ -1637,13 +2222,21 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.2.11",
+                "xtend": "4.0.1"
+            }
         },
         "through2-filter": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            }
         },
         "time-stamp": {
             "version": "1.1.0",
@@ -1655,19 +2248,19 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "dev": true
-        },
-        "to-iso-string": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1"
+            }
         },
         "tough-cookie": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
         },
         "tunnel-agent": {
             "version": "0.4.3",
@@ -1692,7 +2285,11 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -1716,19 +2313,46 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
             "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "extsprintf": "1.0.2"
+            }
         },
         "vinyl": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+            }
         },
         "vinyl-fs": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
+            "requires": {
+                "duplexify": "3.5.0",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
+                "gulp-sourcemaps": "1.6.0",
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.2.11",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
+            },
             "dependencies": {
                 "object-assign": {
                     "version": "4.1.1",
@@ -1740,7 +2364,12 @@
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
                 }
             }
         },
@@ -1749,6 +2378,10 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
             "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
             "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -1766,7 +2399,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -1778,13 +2417,21 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
@@ -1793,18 +2440,39 @@
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.0.tgz",
             "integrity": "sha1-sEwjmbbsdoE1yWiOeHPXduKNy5U=",
             "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.0.0",
+                "gulp-gunzip": "0.0.3",
+                "gulp-remote-src": "0.4.2",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "1.4.0",
+                "mocha": "3.4.2",
+                "request": "2.81.0",
+                "semver": "5.3.0",
+                "source-map-support": "0.4.15",
+                "vinyl-source-stream": "1.1.0"
+            },
             "dependencies": {
                 "commander": {
                     "version": "2.9.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
                 },
                 "debug": {
                     "version": "2.6.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
                     "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "0.7.2"
+                    }
                 },
                 "diff": {
                     "version": "3.2.0",
@@ -1823,12 +2491,33 @@
                     "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
                     "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
                     "dev": true,
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.9.0",
+                        "debug": "2.6.0",
+                        "diff": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.1",
+                        "growl": "1.9.2",
+                        "json3": "3.3.2",
+                        "lodash.create": "3.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "3.1.2"
+                    },
                     "dependencies": {
                         "glob": {
                             "version": "7.1.1",
                             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                             "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
                         }
                     }
                 },
@@ -1842,7 +2531,10 @@
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
                 }
             }
         },
@@ -1861,13 +2553,20 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
             "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
+            }
         },
         "yazl": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
             "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.41",
-        "@types/node": "^6.0.73",
-        "mocha": "^2.3.3",
+        "@types/node": "^8.0.19",
+        "mocha": "^3.5.0",
         "typescript": "^2.3.3",
         "vscode": "^1.1.0"
     },


### PR DESCRIPTION
Would be nice to republish plugin to VSCode. For a while I was sure that the plugin is broken (as cmd+r was not working)